### PR TITLE
Add JDK version 11.0.19_7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 11.0.18_10, 17.0.7_7 ]
+        jdk: [ 11.0.19_7, 17.0.7_7 ]
         android: [ 31, 32, 33 ]
         ndk: [ 25.2.9519653 ]
-        cmake: [ 3.18.1, 3.22.1 ]
+        cmake: [ 3.22.1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
And drop older versions on each of the 11 and 17 LTS branches. Drop CMake 3.18.1 as well.