### PR TITLE
Update JDKs to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 11.0.19_7, 17.0.7_7 ]
+        jdk: [ 11.0.20_8, 17.0.8_7 ]
         android: [ 31, 32, 33, 34 ]
         ndk: [ 25.2.9519653 ]
         cmake: [ 3.22.1 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@
 #
 # Build with custom arguments:
 #
-#   $ ./scripts/build --android 33 --jdk 17.0.7_7 --ndk 25.2.9519653 --cmake 3.22.1
+#   $ ./scripts/build --android 33 --jdk 17.0.8_7 --ndk 25.2.9519653 --cmake 3.22.1
 #
 
-ARG jdk=17.0.7_7
+ARG jdk=17.0.8_7
 ARG android=33
 
 FROM saschpe/android-sdk:${android}-jdk${jdk}

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Android Native Development Kit (NDK) OCI image including CMake based on `saschpe
 
 The following JDK and Android SDK API level combinations are currently supported:
 
-|    | 11.0.19_7 | 17.0.7_7 |
-|----|-----------|----------|
-| 31 | ✅         | ✅        |
-| 32 | ✅         | ✅        |
-| 33 | ✅         | ✅        |
-| 34 | ✅         | ✅        |
+|    | 11.0 | 17.0 |
+|----|------|------|
+| 31 | ✅   | ✅   |
+| 32 | ✅   | ✅   |
+| 33 | ✅   | ✅   |
+| 34 | ✅   | ✅   |
 
 * CMake version: __3.22.1__
 * Android NDK version: __25.2.9519653__


### PR DESCRIPTION
Old tags continue to stay around, add recent JDK releases for automated
builds.
