### PR TITLE
Set read-only permissions and configure Dependabot for workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: ".github/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   IMAGE: saschpe/android-ndk
   PLATFORMS: linux/amd64,linux/arm64
@@ -32,7 +35,7 @@ jobs:
         cmake: [ 3.31.1 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
### Description

This pull request includes updates to enhance the security and maintenance of GitHub Actions workflows:

- Set `contents: read` permissions in `main.yml` to adhere to the principle of least privilege.
- Add a Dependabot configuration to automate dependency updates for Gradle, GitHub Actions, and Docker, scheduled to run weekly. 

### Checklist

- [ ] Tests added/updated as necessary
- [ ] Documentation updated, if applicable