### PR TITLE
Update JDK, NDK, and CMake versions in workflows and docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 17.0.14_7, 21.0.6_7, 22.0.2_9 ]
+        jdk: [ 17.0.14_7, 21.0.6_7, 23.0.2_7 ]
         android: [ 34, 35 ]
-        ndk: [ 26.3.11579264, 27.2.12479018 ]
-        cmake: [ 3.31.1 ]
+        ndk: [ 28.0.13004108 ]
+        cmake: [ 3.31.5 ]
     permissions:
       packages: write
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,17 @@
 #
 # Build with custom arguments:
 #
-#   $ ./scripts/build --android 35 --jdk 22.0.2_9 --ndk 25.2.9519653 --cmake 3.31.1
+#   $ ./scripts/build --android 35 --jdk 23.0.2_7 --ndk 28.0.13004108 --cmake 3.31.5
 #
 
-ARG jdk=22.0.2_9
+ARG jdk=23.0.2_7
 ARG android=35
 
 FROM saschpe/android-sdk:${android}-jdk${jdk}
 ARG android
-ARG cmake=3.31.1
+ARG cmake=3.31.5
 ARG jdk
-ARG ndk=27.2.12479018
+ARG ndk=28.0.13004108
 LABEL maintainer="Sascha Peilicke <sascha@peilicke.de"
 LABEL description="Android NDK ${ndk} with CMake ${cmake} on SDK ${android} using JDK ${jdk}"
 

--- a/README.md
+++ b/README.md
@@ -10,32 +10,32 @@ Docker image `saschpe/android-sdk`.
 
 ## Android SDK, NDK, CMake and JDK support
 
-The following JDK and Android SDK API level combinations are currently
+The following JDK (horizontal axis) and Android SDK API level combinations are currently
 available:
 
-|    | 11 | 17 | 21 | 22 |
-|----|----|----|----|----|
-| 31 | ✅  | ✅  |    |    |
-| 32 | ✅  | ✅  | ✅  | ✅  |
-| 33 | ✅  | ✅  | ✅  | ✅  |
-| 34 | ✅  | ✅  | ✅  | ✅  |
-| 35 |    | ✅  | ✅  | ✅  |
+|    | 11 | 17 | 21 | 22 | 23 |
+|----|----|----|----|----|----|
+| 31 | ✅  | ✅  |    |    |    |
+| 32 | ✅  | ✅  | ✅  | ✅  |    |
+| 33 | ✅  | ✅  | ✅  | ✅  |    | 
+| 34 | ✅  | ✅  | ✅  | ✅  | ✅  | 
+| 35 |    | ✅  | ✅  | ✅  | ✅  |
 
-* Android 35 image NDK versions: __26.2.11394342__ and __27.2.12479018__
-  * Previous images: __25.2.9519653__ and __26.2.11394342__
-* CMake version: __3.31.1__
-  * Previous images: __3.22.1__
+* Android 35 image NDK versions: __27.2.12479018__ and __28.0.13004108__
+    * Previous images: __25.2.9519653__, __26.2.11394342__ and __26.2.11394342__
+* CMake version: __3.31.5__
+    * Previous images: __3.22.1__, __3.31.1__
 
 ## Usage
 
 ```shell
-docker pull saschpe/android-ndk:35-jdk21.0.5_11-ndk27.2.12479018-cmake3.31.1
+docker pull saschpe/android-ndk:35-jdk21.0.5_11-ndk28.0.13004108-cmake3.31.5
 ```
 
 Use as a base image:
 
 ```Dockerfile
-FROM saschpe/android-ndk:35-jdk21.0.5_11-ndk27.2.12479018-cmake3.31.1
+FROM saschpe/android-ndk:35-jdk21.0.5_11-ndk28.0.13004108-cmake3.31.5
 RUN sdkmanager --install emulator
 ```
 


### PR DESCRIPTION
### Description

This pull request updates the following development tools to their latest versions across GitHub workflows, Dockerfile, and documentation:
- **JDK** to version `23.0.2_7`
- **NDK** to version `28.0.13004108`
- **CMake** to version `3.31.5`

Additionally, supported configurations and examples have been updated to ensure compatibility with the latest toolchain updates.